### PR TITLE
feat(adapter): add custom bidder adapter with tests and demo verific…

### DIFF
--- a/modules/bocharovBidAdapter.js
+++ b/modules/bocharovBidAdapter.js
@@ -1,0 +1,112 @@
+// const AUCTION_PATH = 'https://auction.bocharexchange.com/prebid';
+// const BIDDER_CODE = 'bocharov';
+// export const spec = {
+//     code: BIDDER_CODE,
+//     supportedMediaTypes: [BANNER],
+//     isBidRequestValid: function(bid) {
+//         // return if bid invalide
+//     },
+//     buildRequests: (validBidRequests) => {},
+//     interpretResponse: (serverResponse, bidRequest) => {},
+// }
+
+// registerBidder(spec);
+
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER} from '../src/mediaTypes.js';
+import { logInfo, deepAccess, parseSizesInput } from '../src/utils.js';
+
+const BIDDER_CODE = 'bocharov';
+const AUCTION_PATH = 'https://auction.bocharexchange.com/prebid';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  /**
+   * Требуем минимальные параметры: publisherId (строка)
+   * и хотя бы один banner size.
+   */
+  isBidRequestValid(bid) {
+    const pubId = deepAccess(bid, 'params.publisherId');
+    const sizes = deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes;
+    const ok = !!pubId && Array.isArray(sizes) && sizes.length > 0;
+    if (!ok) {
+      logInfo(`[${BIDDER_CODE}] invalid bid`, { bidId: bid.bidId, pubId, sizes });
+    }
+    return ok;
+  },
+
+  /**
+   * Формируем один POST-запрос (chunking не делаем).
+   * В учебных целях главное — увидеть, что запрос "ушёл".
+   */
+  buildRequests(validBidRequests, bidderRequest) {
+    const payload = {
+      bidder: BIDDER_CODE,
+      publisherId: validBidRequests[0]?.params?.publisherId,
+      referer: bidderRequest?.refererInfo?.page,
+      gpp: bidderRequest?.gppConsent?.gppString || bidderRequest?.ortb2?.regs?.gpp,
+      gppSid: bidderRequest?.gppConsent?.applicableSections?.toString() || bidderRequest?.ortb2?.regs?.gpp_sid,
+      bids: validBidRequests.map(bid => ({
+        requestId: bid.bidId,
+        adUnitCode: bid.adUnitCode,
+        sizes: parseSizesInput(
+          deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes
+        ),
+        params: bid.params
+      })),
+    };
+
+    // Просто логируем, чтобы в консоли видеть отправку
+    logInfo(`[${BIDDER_CODE}] buildRequests ->`, payload);
+
+    return {
+      method: 'POST',
+      url: AUCTION_PATH,
+      data: JSON.stringify(payload),
+      options: { contentType: 'application/json' }
+    };
+  },
+
+  /**
+   * Разбираем ответ сервера. Если сервера пока нет, вернём пусто.
+   * Для тестов предусмотрим "мок" формата:
+   * {
+   *   bids: [{
+   *     requestId, cpm, width, height, creativeId, currency, ad
+   *   }]
+   * }
+   */
+  interpretResponse(serverResponse, bidRequest) {
+    const body = serverResponse?.body;
+    if (!body || !Array.isArray(body.bids)) {
+      logInfo(`[${BIDDER_CODE}] empty response`, { serverResponse });
+      return [];
+    }
+    const result = body.bids
+      .filter(b => b && b.cpm > 0)
+      .map(b => ({
+        requestId: b.requestId,
+        cpm: b.cpm,
+        width: b.width,
+        height: b.height,
+        creativeId: b.creativeId || 'bocharov-demo',
+        currency: b.currency || 'USD',
+        netRevenue: true,
+        ttl: 60,
+        ad: b.ad || '<div style="background:#eee;width:100%;height:100%;display:flex;align-items:center;justify-content:center;">Bocharov Demo Creative</div>'
+      }));
+
+    logInfo(`[${BIDDER_CODE}] interpretResponse ->`, result);
+    return result;
+  },
+
+  /**
+   * (Опционально) user sync — здесь пусто для простоты.
+   */
+  getUserSyncs() { return []; }
+};
+
+registerBidder(spec);
+export default spec;

--- a/modules/bocharovBidAdapter.md
+++ b/modules/bocharovBidAdapter.md
@@ -1,0 +1,17 @@
+# Bocharov Bid Adapter (learning/demo)
+
+**Status:** demo/learning  
+**Media types:** Banner
+
+## Params
+| Param        | Type   | Required | Example         |
+|--------------|--------|----------|-----------------|
+| `publisherId`| string | yes      | `demo-pub-123`  |
+
+## Example adUnit
+```js
+const adUnits = [{
+  code: 'div-gpt-bocharov-1',
+  mediaTypes: { banner: { sizes: [[300, 250], [336, 280]] } },
+  bids: [{ bidder: 'bocharov', params: { publisherId: 'demo-pub-123' } }]
+}];

--- a/test/pages/banner.html
+++ b/test/pages/banner.html
@@ -8,7 +8,6 @@
 
 	<!-- Prebid.js -->
 	<script async src="http://localhost:4444/bundle?modules=appnexusBidAdapter"></script>
-
 	<!-- Google Publisher Tag -->
 	<script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
 

--- a/test/spec/modules/bocharovBidAdapter_spec.js
+++ b/test/spec/modules/bocharovBidAdapter_spec.js
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { spec } from 'modules/bocharovBidAdapter.js';
+
+describe('bocharovBidAdapter', function () {
+  const bid = {
+    bidId: '123',
+    adUnitCode: 'div-1',
+    params: { publisherId: 'demo-pub-123' },
+    mediaTypes: { banner: { sizes: [[300, 250]] } }
+  };
+
+  it('validates bids', function () {
+    expect(spec.isBidRequestValid(bid)).to.equal(true);
+    expect(spec.isBidRequestValid({ ...bid, params: {} })).to.equal(false);
+    expect(spec.isBidRequestValid({ ...bid, mediaTypes: { banner: { sizes: [] } } })).to.equal(false);
+  });
+
+  it('builds request', function () {
+    const req = spec.buildRequests([bid], { refererInfo: { page: 'https://site.test' } });
+    expect(req.method).to.equal('POST');
+    expect(req.url).to.contain('bocharexchange.com/prebid');
+    const body = JSON.parse(req.data);
+    expect(body.bidder).to.equal('bocharov');
+    expect(body.publisherId).to.equal('demo-pub-123');
+    expect(body.bids).to.have.length(1);
+    expect(body.bids[0].sizes).to.deep.equal(['300x250']);
+  });
+
+  it('interprets empty response', function () {
+    const res = spec.interpretResponse({ body: null });
+    expect(res).to.be.an('array').that.has.length(0);
+  });
+
+  it('interprets mock bids', function () {
+    const mock = {
+      body: {
+        bids: [{
+          requestId: '123',
+          cpm: 0.5,
+          width: 300,
+          height: 250,
+          creativeId: 'cr-1',
+          currency: 'USD',
+          ad: '<div>demo</div>'
+        }]
+      }
+    };
+    const parsed = spec.interpretResponse(mock, {});
+    expect(parsed).to.have.length(1);
+    expect(parsed[0].requestId).to.equal('123');
+    expect(parsed[0].cpm).to.equal(0.5);
+    expect(parsed[0].ad).to.contain('demo');
+  });
+});


### PR DESCRIPTION
- Implement minimal banner-only Bocharov adapter
- Add unit tests (isBidRequestValid, buildRequests, interpretResponse)
- Add adapter docs
- Verified on test/pages/banner.html (request sent; mock creative renders)

Build note: tested with modules bocharov, adtelligent, bidmatic.
![Task 5 - Bocharov - Adapter work 2](https://github.com/user-attachments/assets/af5a3cd2-6a32-4ae5-bf2d-a509f5429178)
![Task 5 - Bocharov - Adapter work](https://github.com/user-attachments/assets/24f61685-3996-437c-9773-2e8a4eed1d37)

